### PR TITLE
Update VS Attributon namespace

### DIFF
--- a/Editor/VSAttribution.cs
+++ b/Editor/VSAttribution.cs
@@ -3,7 +3,9 @@ using UnityEngine;
 using UnityEditor;
 using UnityEngine.Analytics;
 
-namespace UnityEditor.VSAttribution
+// Prefix this namespace with a name that matches your other product namespaces
+// Example: [ProductName].VS
+namespace VS
 {
 	public static class VSAttribution
 	{

--- a/Editor/VSAttribution.cs
+++ b/Editor/VSAttribution.cs
@@ -3,7 +3,7 @@ using UnityEngine;
 using UnityEditor;
 using UnityEngine.Analytics;
 
-// Prefix this namespace with a name that matches your other product namespaces
+// Prefix this namespace with a keyword that matches your product's other namespaces
 // Example: [ProductName].VS
 namespace VS
 {

--- a/Samples~/StaticScriptSample.cs
+++ b/Samples~/StaticScriptSample.cs
@@ -1,6 +1,6 @@
 using UnityEditor;
 using UnityEngine;
-using UnityEditor.VSAttribution;
+using VS;
 
 public class StaticScriptSample : EditorWindow
 {


### PR DESCRIPTION
Update VS Attribution namespace to avoid violating the 2.5.a clause of the Asset Store Submission Guidelines:

> 2.5.a All code is contained in user declared namespaces. Code cannot be contained in official Unity namespaces or those that include Unity or any other trademarks. You can find more information about namespaces[ in Microsoft's C# documentation](https://docs.microsoft.com/en-us/dotnet/csharp/fundamentals/types/namespaces).